### PR TITLE
perf: add SQLite statement caching and performance optimizations

### DIFF
--- a/electron/main/infra/db/connection.ts
+++ b/electron/main/infra/db/connection.ts
@@ -30,6 +30,8 @@ export function openDatabase(): Database.Database {
 	logger.info("Opening database at:", dbPath);
 	db = new Database(dbPath);
 	db.pragma("foreign_keys = ON");
+	db.pragma("journal_mode = WAL");
+	db.pragma("synchronous = NORMAL");
 	return db;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,17 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
+export function debounce<T extends (...args: unknown[]) => void>(
+	fn: T,
+	ms: number
+): (...args: Parameters<T>) => void {
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	return (...args: Parameters<T>) => {
+		if (timeoutId) clearTimeout(timeoutId);
+		timeoutId = setTimeout(() => fn(...args), ms);
+	};
+}
+
 export function formatRelativeTime(timestamp: number): string {
 	const now = Date.now();
 	const diff = now - timestamp;
@@ -71,11 +82,13 @@ export function formatBytes(bytes: number): string {
 	const maximumFractionDigits =
 		unitIndex === 0 ? 0 : value >= 100 ? 0 : value >= 10 ? 1 : 2;
 
-	return `${new Intl.NumberFormat(undefined, { maximumFractionDigits }).format(value)} ${units[unitIndex]}`;
+	return `${new Intl.NumberFormat(undefined, {
+		maximumFractionDigits,
+	}).format(value)} ${units[unitIndex]}`;
 }
 
 export function groupEventsByDate<T extends { timestamp: number }>(
-	events: T[],
+	events: T[]
 ): Map<string, T[]> {
 	const groups = new Map<string, T[]>();
 	const today = new Date();


### PR DESCRIPTION
> Firstly, thank you for this great project and making it FOSS.
Secondly, I was experiencing 100% CPU usage so I vibe coded this fix using Claude Code and Gemini. I'm marking it as a DRAFT PR. Looking forward to your feedback.

- Enable WAL mode for better concurrent read/write performance
- Cache prepared statements for insertEvent, getEventById, getEvents
- Add debouncing (150ms) to useEvents hook IPC listeners
- Add 1-hour negative cache for failed favicon downloads
- Add debounce utility function to utils.ts

These optimizations reduce main process CPU usage from 100% to <1% in production. The high CPU in dev mode is caused by Vite HMR invalidating module-level caches.