### PR TITLE
fix: catch scheduler tick rejections

### DIFF
--- a/electron/main/features/scheduler/SchedulerService.ts
+++ b/electron/main/features/scheduler/SchedulerService.ts
@@ -288,7 +288,9 @@ export function startScheduler(intervalMinutes?: number): void {
 	});
 
 	captureInterval = setInterval(() => {
-		tick();
+		void tick().catch((error) => {
+			logger.error("Scheduler tick failed", error);
+		});
 	}, intervalMs);
 }
 

--- a/electron/main/features/scheduler/__tests__/SchedulerService.test.ts
+++ b/electron/main/features/scheduler/__tests__/SchedulerService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const powerMonitor = { getSystemIdleTime: vi.fn(() => 0) };
 const screen = { getPrimaryDisplay: vi.fn(() => ({ id: 1 })) };
@@ -7,6 +7,16 @@ vi.mock("electron", () => ({
 	powerMonitor,
 	screen,
 	BrowserWindow: { getAllWindows: () => [] },
+}));
+
+const logger = {
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+};
+vi.mock("../../../infra/log", () => ({
+	createLogger: () => logger,
 }));
 
 const updateEvent = vi.fn();
@@ -37,9 +47,13 @@ vi.mock("../../events", () => ({
 }));
 
 const getLastKnownCandidate = vi.fn(() => null);
+const discardActivityWindow = vi.fn();
+const finalizeActivityWindow = vi.fn();
 const startActivityWindowTracking = vi.fn();
 const stopActivityWindowTracking = vi.fn();
 vi.mock("../../activityWindow", () => ({
+	discardActivityWindow,
+	finalizeActivityWindow,
 	getLastKnownCandidate,
 	startActivityWindowTracking,
 	stopActivityWindowTracking,
@@ -63,6 +77,10 @@ vi.mock("../../context", () => ({
 }));
 
 describe("SchedulerService (manual capture)", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	beforeEach(() => {
 		vi.resetModules();
 		vi.clearAllMocks();
@@ -180,5 +198,22 @@ describe("SchedulerService (manual capture)", () => {
 		);
 		expect(startActivityWindowTracking).toHaveBeenCalledTimes(1);
 		expect(stopActivityWindowTracking).toHaveBeenCalledTimes(2);
+	});
+
+	it("logs scheduled tick failures instead of leaking an unhandled rejection", async () => {
+		vi.useFakeTimers();
+		checkScreenCapturePermission.mockReturnValue(true);
+		const error = new Error("finalize failed");
+		finalizeActivityWindow.mockRejectedValue(error);
+
+		const { startScheduler, stopScheduler } = await import(
+			"../SchedulerService"
+		);
+
+		startScheduler(1);
+		await vi.advanceTimersByTimeAsync(60_000);
+		stopScheduler();
+
+		expect(logger.error).toHaveBeenCalledWith("Scheduler tick failed", error);
 	});
 });


### PR DESCRIPTION
## Summary
- catch and log rejected scheduler tick promises in the scheduler interval callback
- add a regression test that forces a scheduled capture failure and verifies it is logged
- confirm issue #6 is valid: `startScheduler()` previously invoked `tick()` without handling the returned promise

## Testing
- npm test -- electron/main/features/scheduler/__tests__/SchedulerService.test.ts
- npx biome check electron/main/features/scheduler/SchedulerService.ts electron/main/features/scheduler/__tests__/SchedulerService.test.ts
- npm run typecheck

Closes #6